### PR TITLE
Add Django 2.2 and Python 3.7 to tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
+dist: xenial
 language: python
+
 python:
-  - "3.6"
+  - 3.4
+  - 3.5
+  - 3.6
+  - 3.7
 
 install:
-  - pip install tox
+  - pip install tox-travis
 
 script:
-  - tox --skip-missing-interpreters
+  - tox

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+0.4.4
+-----
+- Add support for Django 2.1, 2.2.
+- Add support for Python 3.7.
+
 0.4.3
 -----
 - Fix exception thrown by middleware when processing a request with a malformed Authorization header.

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -10,9 +10,36 @@ INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
+    'django.contrib.messages',
     'django.contrib.sessions',
     'django.contrib.sites',
     'asymmetric_jwt_auth',
+]
+
+MIDDLEWARE = [
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+]
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+        ],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
 ]
 
 DATABASES = {

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,16 @@
 [tox]
 toxworkdir={env:TOX_WORK_DIR:.tox}
-envlist = py{34,35,36}-django{111,200}
+envlist =
+    py{34,35,36,37}-django{111,20}
+    py{35,36,37}-django{21,22}
 
 [testenv]
 extras = development
 deps =
-    django111: django>=1.11,<1.12
-    django200: django>=2.0,<2.1
+    django111: django>=1.11,<2
+    django20: django>=2.0,<2.1
+    django21: django>=2.1,<2.2
+    django22: django>=2.2,<2.3
 commands =
     flake8 src sandbox setup.py
     {envpython} {toxinidir}/sandbox/manage.py test asymmetric_jwt_auth


### PR DESCRIPTION
- Add Django 2.1 and 2.2 to test suite
- Add Python 3.7 to test suite
- Update .travis.yml to run tests for all python versions
- Use tox-travis to smartly run the correct python+django version combos defined in the tox.ini
- Update sandbox/settings.py to resolve errors thrown by django 2.2

Also, I went out on a limb and updated the changelog, recognizing there's a decent chance that ends up being unhelpful.